### PR TITLE
enhancement: add nix flake and multistage friendly OCI with expanded LLVM 21 support

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,0 +1,130 @@
+name: Nix Build
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'flake.nix'
+      - 'flake.lock'
+      - 'compiler/**'
+      - 'runtime/**'
+      - 'modules/**'
+      - 'tools/**'
+      - 'util/**'
+      - 'make/**'
+      - 'Makefile*'
+  pull_request:
+    paths:
+      - 'flake.nix'
+      - 'flake.lock'
+      - 'compiler/**'
+      - 'runtime/**'
+      - 'modules/**'
+      - 'tools/**'
+      - 'util/**'
+      - 'make/**'
+      - 'Makefile*'
+  workflow_dispatch:
+
+jobs:
+  flake-check:
+    name: Nix Flake Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v27
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+
+      - name: Check flake
+        run: nix flake check --no-build
+
+      - name: Show flake info
+        run: nix flake show
+
+  build-chapel-gnu:
+    name: Build Chapel (GNU backend)
+    runs-on: ubuntu-latest
+    needs: flake-check
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v27
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+
+      - name: Build chapel-gnu
+        run: |
+          nix build .#chapel-gnu --print-build-logs
+          ./result/bin/chpl --version
+
+  build-chapel-bundled-llvm:
+    name: Build Chapel (Bundled LLVM - supports LLVM 21)
+    runs-on: ubuntu-latest
+    needs: flake-check
+    # This is a long build (~4GB memory), only run on main or when explicitly requested
+    if: github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v27
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+
+      - name: Build chapel (bundled LLVM)
+        run: |
+          nix build .#chapel --print-build-logs
+          ./result/bin/chpl --version
+
+  build-chapel-system-llvm:
+    name: Build Chapel (System LLVM 19)
+    runs-on: ubuntu-latest
+    needs: flake-check
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v27
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+
+      - name: Build chapel-system-llvm
+        run: |
+          nix build .#chapel-system-llvm --print-build-logs
+          ./result/bin/chpl --version
+
+  dev-shell:
+    name: Test Dev Shell
+    runs-on: ubuntu-latest
+    needs: flake-check
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v27
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+
+      - name: Test chapel-dev shell
+        run: |
+          nix develop .#chapel-dev --command bash -c '
+            echo "Testing chapel-dev shell..."
+            echo "CHPL_LLVM=$CHPL_LLVM"
+            echo "CHPL_LLVM_CONFIG=$CHPL_LLVM_CONFIG"
+            which clang
+            llvm-config --version
+          '

--- a/Containerfile.multi-stage
+++ b/Containerfile.multi-stage
@@ -1,0 +1,277 @@
+# Multi-Stage Chapel Container Build
+# Optimized for modular deployment with specialized variants
+# Author: Jess Sullivan (@Jesssullivan)
+# Based on research: PACKAGING-RESEARCH.md
+#
+# LLVM Version Support:
+#   - Chapel 2.7 supports LLVM 14-21
+#   - Default is LLVM 21 (latest supported, requires LLVM.org apt repo)
+#   - For older systems, use LLVM_VERSION=19 or LLVM_VERSION=18
+#
+# Build examples:
+#   podman build --target chapel-full -t chapel:2.7.0 .
+#   podman build --build-arg LLVM_VERSION=19 --target chapel-full -t chapel:2.7.0-llvm19 .
+
+ARG LLVM_VERSION=21
+ARG CHAPEL_VERSION=2.7.0
+ARG DEBIAN_VERSION=bookworm-slim
+
+# =============================================================================
+# Stage 1: LLVM Builder (optional, for bundled LLVM builds)
+# =============================================================================
+FROM debian:${DEBIAN_VERSION} AS llvm-builder
+
+ARG LLVM_VERSION
+ARG TARGETARCH
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential cmake ninja-build python3 git ca-certificates \
+    wget curl file \
+    && rm -rf /var/lib/apt/lists/*
+
+# For bundled LLVM builds, Chapel includes LLVM 19.1.3
+# This stage can be used if building custom LLVM
+WORKDIR /opt/llvm-src
+
+# Placeholder for custom LLVM build if needed
+# Chapel's bundled LLVM (CHPL_LLVM=bundled) is recommended for most cases
+
+# =============================================================================
+# Stage 2: Chapel Builder
+# =============================================================================
+FROM debian:${DEBIAN_VERSION} AS chapel-builder
+
+ARG LLVM_VERSION
+ARG CHAPEL_VERSION
+ARG CHPL_LLVM=system
+ARG CHPL_COMM=none
+ARG CHPL_TARGET_CPU=none
+ARG TARGETARCH
+
+# Install build dependencies
+# For LLVM versions not in Debian repos (e.g., 20, 21), we add LLVM.org's apt repo
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    bash ca-certificates curl wget file locales git mawk make cmake m4 \
+    perl pkg-config gnupg lsb-release software-properties-common \
+    gcc g++ \
+    libgmp-dev protobuf-compiler libedit-dev \
+    python3 python3-dev python3-pip python3-venv python3-setuptools \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install LLVM - use LLVM.org repo for versions >= 20
+RUN set -eux; \
+    if [ "${LLVM_VERSION}" -ge 20 ]; then \
+        wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor -o /usr/share/keyrings/llvm-archive-keyring.gpg; \
+        echo "deb [signed-by=/usr/share/keyrings/llvm-archive-keyring.gpg] https://apt.llvm.org/$(lsb_release -cs)/ llvm-toolchain-$(lsb_release -cs)-${LLVM_VERSION} main" > /etc/apt/sources.list.d/llvm.list; \
+        apt-get update; \
+    fi; \
+    apt-get install -y --no-install-recommends \
+        clang-${LLVM_VERSION} llvm-${LLVM_VERSION} llvm-${LLVM_VERSION}-dev \
+        libclang-${LLVM_VERSION}-dev libclang-cpp${LLVM_VERSION}-dev; \
+    rm -rf /var/lib/apt/lists/*
+
+# Configure locale
+RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen \
+    && dpkg-reconfigure --frontend=noninteractive locales
+
+# Configure git for mason tests
+RUN git config --global user.email "noreply@example.com" \
+    && git config --global user.name "Chapel Builder"
+
+ENV CHPL_HOME=/opt/chapel \
+    CHPL_LLVM=${CHPL_LLVM} \
+    CHPL_COMM=${CHPL_COMM} \
+    CHPL_TARGET_CPU=${CHPL_TARGET_CPU} \
+    CHPL_GMP=system \
+    LANG=en_US.UTF-8
+
+WORKDIR ${CHPL_HOME}
+
+# Download Chapel source (replace with COPY . . for local builds)
+RUN wget -qO- https://github.com/chapel-lang/chapel/releases/download/${CHAPEL_VERSION}/chapel-${CHAPEL_VERSION}.tar.gz | tar xz --strip-components=1
+
+# Build Chapel with both backends
+RUN source util/setchplenv.bash \
+    && CHPL_TARGET_COMPILER=llvm make -j$(nproc) \
+    && CHPL_TARGET_COMPILER=gnu make -j$(nproc)
+
+# Build all tools
+RUN source util/setchplenv.bash \
+    && make chpldoc mason chapel-py-venv chplcheck chpl-language-server
+
+# Clean build artifacts to reduce image size
+RUN make cleanall \
+    && rm -rf .git test/release third-party/llvm/llvm-src \
+    && find . -name "*.o" -delete \
+    && find . -name "*.a" -delete
+
+# Create symlinks for easy access
+RUN cd ${CHPL_HOME}/bin && \
+    for dir in */; do \
+        ln -sf "${dir}"* . 2>/dev/null || true; \
+    done
+
+# =============================================================================
+# Stage 3: Full Development Image
+# =============================================================================
+FROM debian:${DEBIAN_VERSION} AS chapel-full
+
+ARG LLVM_VERSION
+
+# Install runtime dependencies and LLVM
+# For LLVM versions >= 20, use LLVM.org repo
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    bash ca-certificates git make wget gnupg lsb-release \
+    gcc g++ \
+    libgmp10 libedit2 \
+    python3 python3-venv locales \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install LLVM from appropriate source
+RUN set -eux; \
+    if [ "${LLVM_VERSION}" -ge 20 ]; then \
+        wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor -o /usr/share/keyrings/llvm-archive-keyring.gpg; \
+        echo "deb [signed-by=/usr/share/keyrings/llvm-archive-keyring.gpg] https://apt.llvm.org/$(lsb_release -cs)/ llvm-toolchain-$(lsb_release -cs)-${LLVM_VERSION} main" > /etc/apt/sources.list.d/llvm.list; \
+        apt-get update; \
+    fi; \
+    apt-get install -y --no-install-recommends \
+        clang-${LLVM_VERSION} llvm-${LLVM_VERSION} llvm-${LLVM_VERSION}-dev \
+        libclang-${LLVM_VERSION}-dev libclang-cpp${LLVM_VERSION}-dev; \
+    rm -rf /var/lib/apt/lists/*
+
+# Configure locale
+RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen \
+    && dpkg-reconfigure --frontend=noninteractive locales
+
+ENV CHPL_HOME=/opt/chapel \
+    LANG=en_US.UTF-8 \
+    PATH="/opt/chapel/bin:/opt/chapel/util:${PATH}"
+
+COPY --from=chapel-builder /opt/chapel /opt/chapel
+
+LABEL org.opencontainers.image.title="Chapel Programming Language" \
+      org.opencontainers.image.description="Full Chapel development environment with LLVM backend" \
+      org.opencontainers.image.source="https://github.com/Jesssullivan/chapel" \
+      org.opencontainers.image.licenses="Apache-2.0" \
+      org.opencontainers.image.authors="Jess Sullivan <jess@sulliwood.org>"
+
+WORKDIR /workspace
+
+CMD ["/bin/bash"]
+
+# =============================================================================
+# Stage 4: LSP-Only Image (for editor integration)
+# =============================================================================
+FROM python:3.12-slim AS chapel-lsp
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libgmp10 libedit2 \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV CHPL_HOME=/opt/chapel \
+    PATH="/opt/chapel/bin:${PATH}"
+
+# Copy only LSP-related components
+COPY --from=chapel-builder /opt/chapel/bin/chpl-language-server* /opt/chapel/bin/
+COPY --from=chapel-builder /opt/chapel/bin/chplcheck* /opt/chapel/bin/
+COPY --from=chapel-builder /opt/chapel/lib/chapel-py* /opt/chapel/lib/
+COPY --from=chapel-builder /opt/chapel/runtime /opt/chapel/runtime
+
+LABEL org.opencontainers.image.title="Chapel Language Server" \
+      org.opencontainers.image.description="Chapel LSP for editor integration" \
+      org.opencontainers.image.source="https://github.com/Jesssullivan/chapel"
+
+EXPOSE 2089
+
+ENTRYPOINT ["chpl-language-server"]
+CMD ["--stdio"]
+
+# =============================================================================
+# Stage 5: Runtime-Only Image (minimal for running Chapel binaries)
+# =============================================================================
+FROM debian:${DEBIAN_VERSION} AS chapel-runtime
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libgmp10 libedit2 libstdc++6 \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV CHPL_HOME=/opt/chapel \
+    PATH="/opt/chapel/bin:${PATH}"
+
+# Copy only runtime libraries
+COPY --from=chapel-builder /opt/chapel/lib/runtime /opt/chapel/lib/runtime
+COPY --from=chapel-builder /opt/chapel/runtime /opt/chapel/runtime
+
+LABEL org.opencontainers.image.title="Chapel Runtime" \
+      org.opencontainers.image.description="Minimal Chapel runtime for executing pre-compiled binaries" \
+      org.opencontainers.image.source="https://github.com/Jesssullivan/chapel"
+
+WORKDIR /workspace
+
+CMD ["/bin/bash"]
+
+# =============================================================================
+# Stage 6: GASNet Multi-Locale Image
+# =============================================================================
+FROM chapel-builder AS chapel-gasnet-builder
+
+ENV CHPL_COMM=gasnet \
+    CHPL_COMM_SUBSTRATE=smp
+
+RUN source util/setchplenv.bash \
+    && make -j$(nproc)
+
+FROM debian:${DEBIAN_VERSION} AS chapel-gasnet
+
+ARG LLVM_VERSION
+
+# Install runtime dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    bash ca-certificates git make wget gnupg lsb-release \
+    gcc g++ \
+    libgmp10 libedit2 \
+    python3 python3-venv \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install LLVM from appropriate source
+RUN set -eux; \
+    if [ "${LLVM_VERSION}" -ge 20 ]; then \
+        wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor -o /usr/share/keyrings/llvm-archive-keyring.gpg; \
+        echo "deb [signed-by=/usr/share/keyrings/llvm-archive-keyring.gpg] https://apt.llvm.org/$(lsb_release -cs)/ llvm-toolchain-$(lsb_release -cs)-${LLVM_VERSION} main" > /etc/apt/sources.list.d/llvm.list; \
+        apt-get update; \
+    fi; \
+    apt-get install -y --no-install-recommends \
+        clang-${LLVM_VERSION} llvm-${LLVM_VERSION}; \
+    rm -rf /var/lib/apt/lists/*
+
+ENV CHPL_HOME=/opt/chapel \
+    CHPL_COMM=gasnet \
+    PATH="/opt/chapel/bin:/opt/chapel/util:${PATH}"
+
+COPY --from=chapel-gasnet-builder /opt/chapel /opt/chapel
+
+LABEL org.opencontainers.image.title="Chapel with GASNet" \
+      org.opencontainers.image.description="Chapel with GASNet for multi-locale execution" \
+      org.opencontainers.image.source="https://github.com/Jesssullivan/chapel"
+
+WORKDIR /workspace
+
+CMD ["/bin/bash"]
+
+# =============================================================================
+# Build Instructions
+# =============================================================================
+#
+# Build all variants:
+#   podman build --target chapel-full -t ghcr.io/jesssullivan/chapel:2.7.0-full .
+#   podman build --target chapel-lsp -t ghcr.io/jesssullivan/chapel:2.7.0-lsp .
+#   podman build --target chapel-runtime -t ghcr.io/jesssullivan/chapel:2.7.0-runtime .
+#   podman build --target chapel-gasnet -t ghcr.io/jesssullivan/chapel:2.7.0-gasnet .
+#
+# Multi-arch build:
+#   podman buildx build --platform linux/amd64,linux/arm64 \
+#     --target chapel-full -t ghcr.io/jesssullivan/chapel:2.7.0-full --push .
+#
+# Test locally:
+#   podman run -it --rm ghcr.io/jesssullivan/chapel:2.7.0-full chpl --version
+#   podman run -it --rm ghcr.io/jesssullivan/chapel:2.7.0-lsp chpl-language-server --help

--- a/compiler/codegen/cg-CForLoop.cpp
+++ b/compiler/codegen/cg-CForLoop.cpp
@@ -206,7 +206,7 @@ static llvm::MDNode* generateLoopMetadata(LoopStmt* loop,
 
   std::vector<llvm::Metadata*> args;
   // Resolve operand 0 for the loop id self reference
-  auto tmpNode        = llvm::MDNode::getTemporary(ctx, chpl::empty);
+  auto tmpNode        = llvm::MDNode::getTemporary(ctx, {});
   args.push_back(tmpNode.get());
 
   if(fNoVectorize == false && loop->isVectorizable()) {

--- a/compiler/codegen/cg-expr.cpp
+++ b/compiler/codegen/cg-expr.cpp
@@ -530,11 +530,11 @@ GenRet codegenWideAddr(GenRet locale, GenRet raddr, Type* wideType = NULL)
     llvm::Type* locAddrType = nullptr;
 
     if (isOpaquePointer(addrType)) {
-      locAddrType = llvm::PointerType::getUnqual(gContext->llvmContext());
+      locAddrType = getPointerType(gContext->llvmContext());
     } else {
 #ifdef HAVE_LLVM_TYPED_POINTERS
       locAddrType =
-        llvm::PointerType::getUnqual(addrType->getPointerElementType());
+        getPointerType(addrType->getPointerElementType());
 #endif
     }
     INT_ASSERT(locAddrType);
@@ -1304,7 +1304,7 @@ GenRet doCodegenFieldPtr(
           baseTy, baseValue, cBaseType->getMemberGEP("_u", unused));
       trackLLVMValue(ret.val);
       auto addrSpace = baseValue->getType()->getPointerAddressSpace();
-      llvm::PointerType* ty = llvm::PointerType::get(retType.type, addrSpace);
+      auto ty = getPointerType(retType.type, addrSpace);
       // Now cast it to the right type.
       ret.val = convertValueToType(ret.val, ty, false);
       INT_ASSERT(ret.val);
@@ -1342,8 +1342,7 @@ GenRet doCodegenFieldPtr(
             (ret.chplType == dtCFnPtr)) {
           // cast the returned pointer to the right type
           auto addrSpace = baseValue->getType()->getPointerAddressSpace();
-          llvm::PointerType* ty =
-            llvm::PointerType::get(retType.type, addrSpace);
+          auto ty = getPointerType(retType.type, addrSpace);
           ret.val = convertValueToType(ret.val, ty, false);
         }
 
@@ -2201,6 +2200,20 @@ GenRet codegenMod(GenRet a, GenRet b)
   return ret;
 }
 
+#ifdef HAVE_LLVM
+static llvm::CallInst* CreateIntrinsic(llvm::Intrinsic::ID id,
+                                        llvm::ArrayRef<llvm::Type*> tys,
+                                        llvm::ArrayRef<llvm::Value*> args) {
+#if LLVM_VERSION_MAJOR >= 21
+  auto call = gGenInfo->irBuilder->CreateIntrinsic(id, tys, args, {});
+#else
+  auto call = gGenInfo->irBuilder->CreateIntrinsic(id, tys, args);
+#endif
+  trackLLVMValue(call);
+  return call;
+}
+#endif
+
 // TODO: We could call the C 'fma' function from 'math.h' here.
 static GenRet emitFmaForC(GenRet av, GenRet bv, GenRet cv) {
   INT_FATAL("Should not reach here, user facing functions should call the "
@@ -2212,7 +2225,6 @@ static GenRet emitFmaForC(GenRet av, GenRet bv, GenRet cv) {
 static GenRet emitFmaForLlvm(GenRet av, GenRet bv, GenRet cv) {
   GenRet ret;
 #ifdef HAVE_LLVM
-  GenInfo* info = gGenInfo;
   INT_ASSERT(av.chplType == bv.chplType && bv.chplType == cv.chplType);
   INT_ASSERT(av.chplType == dtReal[FLOAT_SIZE_64] ||
              av.chplType == dtReal[FLOAT_SIZE_32]);
@@ -2229,7 +2241,7 @@ static GenRet emitFmaForLlvm(GenRet av, GenRet bv, GenRet cv) {
   auto id = llvm::Intrinsic::fma;
   std::vector<llvm::Type*> tys = { ty };
   std::vector<llvm::Value*> args = { av.val, bv.val, cv.val };
-  ret.val = info->irBuilder->CreateIntrinsic(id, tys, args);
+  ret.val = CreateIntrinsic(id, tys, args);
   trackLLVMValue(ret.val);
 #endif
 
@@ -2276,7 +2288,6 @@ static GenRet emitSqrtCMath(GenRet av) {
 static GenRet emitSqrtLLVMIntrinsic(GenRet av) {
   GenRet ret;
 #ifdef HAVE_LLVM
-  GenInfo* info = gGenInfo;
   INT_ASSERT(av.chplType == dtReal[FLOAT_SIZE_64] ||
              av.chplType == dtReal[FLOAT_SIZE_32]);
   auto ty = av.val->getType();
@@ -2288,7 +2299,7 @@ static GenRet emitSqrtLLVMIntrinsic(GenRet av) {
   auto id = llvm::Intrinsic::sqrt;
   std::vector<llvm::Type*> tys = { ty };
   std::vector<llvm::Value*> args = { av.val };
-  ret.val = info->irBuilder->CreateIntrinsic(id, tys, args);
+  ret.val = CreateIntrinsic(id, tys, args);
   trackLLVMValue(ret.val);
 #endif
 
@@ -2323,7 +2334,6 @@ static GenRet emitAbsCMath(GenRet av) {
 static GenRet emitAbsLLVMIntrinsic(GenRet av) {
   GenRet ret;
 #ifdef HAVE_LLVM
-  GenInfo* info = gGenInfo;
   INT_ASSERT(av.chplType == dtReal[FLOAT_SIZE_64] ||
              av.chplType == dtReal[FLOAT_SIZE_32]);
   auto ty = av.val->getType();
@@ -2335,7 +2345,7 @@ static GenRet emitAbsLLVMIntrinsic(GenRet av) {
   auto id = llvm::Intrinsic::fabs;
   std::vector<llvm::Type*> tys = { ty };
   std::vector<llvm::Value*> args = { av.val };
-  ret.val = info->irBuilder->CreateIntrinsic(id, tys, args);
+  ret.val = CreateIntrinsic(id, tys, args);
   trackLLVMValue(ret.val);
 #endif
 
@@ -2993,8 +3003,8 @@ static GenRet codegenCallExprInner(GenRet function,
                 tmp = createTempVarWith(args[i]);
 
                 llvm::Value* ptr = tmp.val;
-                llvm::Type* sTyPtrTy = llvm::PointerType::get(sTy, stackSpace);
-                llvm::Type* i8PtrTy = getPointerType(irBuilder);
+                auto sTyPtrTy = getPointerType(sTy, stackSpace);
+                auto i8PtrTy = getPointerType(irBuilder);
 
                 // handle offset
                 if (unsigned offset = argInfo->getDirectOffset()) {
@@ -3040,7 +3050,7 @@ static GenRet codegenCallExprInner(GenRet function,
             // Create a temp variable to load from
             tmp = createTempVarWith(args[i]);
 
-            llvm::Type* sTyPtrTy = llvm::PointerType::get(sTy, stackSpace);
+            auto sTyPtrTy = getPointerType(sTy, stackSpace);
             llvm::Value* ptr = irBuilder->CreatePointerCast(tmp.val, sTyPtrTy);
             trackLLVMValue(ptr);
 
@@ -3105,7 +3115,7 @@ static GenRet codegenCallExprInner(GenRet function,
       // If we are using typed pointers, the pointer type must match the
       // call type or else instruction verification will fail. If using
       // opaque pointers, it is fine if the call pointer type is 'void*'.
-      auto fnPtrType = llvm::PointerType::getUnqual(fnType);
+      auto fnPtrType = getPointerType(fnType);
       val = info->irBuilder->CreateBitCast(val, fnPtrType);
     #endif
 
@@ -3466,7 +3476,7 @@ GenRet codegenNullPointer()
     ret.c = "NULL";
   } else {
 #ifdef HAVE_LLVM
-    llvm::Type* ptrType = getPointerType(info->irBuilder);
+    auto ptrType = getPointerType(info->irBuilder);
     ret.val = llvm::Constant::getNullValue(ptrType);
 #endif
   }
@@ -3503,8 +3513,8 @@ void codegenCallMemcpy(GenRet dest, GenRet src, GenRet size,
     llvm::Type *types[3];
     unsigned addrSpaceDest = llvm::cast<llvm::PointerType>(dest.val->getType())->getAddressSpace();
     unsigned addrSpaceSrc = llvm::cast<llvm::PointerType>(src.val->getType())->getAddressSpace();
-    types[0] = llvm::PointerType::get(int8Ty, addrSpaceDest);
-    types[1] = llvm::PointerType::get(int8Ty, addrSpaceSrc);
+    types[0] = getPointerType(int8Ty, addrSpaceDest);
+    types[1] = getPointerType(int8Ty, addrSpaceSrc);
     types[2] = llvm::Type::getInt64Ty(gContext->llvmContext());
     //types[3] = llvm::Type::getInt32Ty(info->llvmContext);
     //types[4] = llvm::Type::getInt1Ty(info->llvmContext);
@@ -3796,7 +3806,7 @@ GenRet codegenCastToVoidStar(GenRet value)
     ret.c += "))";
   } else {
 #ifdef HAVE_LLVM
-    llvm::Type* castType = getPointerType(info->irBuilder);
+    auto castType = getPointerType(info->irBuilder);
     ret.val = convertValueToType(value.val, castType, !value.isUnsigned);
     INT_ASSERT(ret.val);
 #endif
@@ -5586,7 +5596,7 @@ DEFINE_PRIM(GPU_ALLOC_SHARED) {
   trackLLVMValue(sharedArray);
 
   // Get a void* pointer to the shared array.
-  llvm::Type* voidPtrType = getPointerType(gContext->llvmContext(), 3);
+  auto voidPtrType = getPointerType(gContext->llvmContext(), 3);
   llvm::Value* sharedArrayPtr = gGenInfo->irBuilder->CreateBitCast(sharedArray, voidPtrType, "sharedArrayPtr");
   trackLLVMValue(sharedArrayPtr);
 
@@ -6294,14 +6304,14 @@ DEFINE_PRIM(FTABLE_CALL) {
       argt = call->get(2)->typeInfo()->codegen().type;
 
       if (argMustUseCPtr(call->get(2)->typeInfo()))
-        argt = llvm::PointerType::getUnqual(argt);
+        argt = getPointerType(argt);
 
       argumentTypes.push_back(argt);
 
       argt = call->get(3)->typeInfo()->codegen().type;
 
       if (argMustUseCPtr(call->get(3)->typeInfo()))
-        argt = llvm::PointerType::getUnqual(argt);
+        argt = getPointerType(argt);
 
       argumentTypes.push_back(argt);
 
@@ -6311,7 +6321,7 @@ DEFINE_PRIM(FTABLE_CALL) {
 
       // OK, now cast to the fnTy.
       fngen.val = gGenInfo->irBuilder->CreateBitCast(fnPtr,
-                                                    llvm::PointerType::getUnqual(fnTy));
+                                                    getPointerType(fnTy));
       trackLLVMValue(fngen.val);
 #endif
     }
@@ -6413,7 +6423,7 @@ llvm::MDNode* createMetadataScope(llvm::LLVMContext& ctx,
                                     const char* name) {
 
   auto scopeName = llvm::MDString::get(ctx, name);
-  auto dummy = llvm::MDNode::getTemporary(ctx, chpl::empty);
+  auto dummy = llvm::MDNode::getTemporary(ctx, {});
   llvm::Metadata* Args[] = {dummy.get(), domain, scopeName};
   auto scope = llvm::MDNode::get(ctx, Args);
   // Remove the dummy and replace it with a self-reference.
@@ -6437,7 +6447,7 @@ DEFINE_PRIM(NO_ALIAS_SET) {
 
     if (info->noAliasDomain == NULL) {
       auto domainName = llvm::MDString::get(ctx, "Chapel no-alias");
-      auto dummy = llvm::MDNode::getTemporary(ctx, chpl::empty);
+      auto dummy = llvm::MDNode::getTemporary(ctx, {});
       llvm::Metadata* Args[] = {dummy.get(), domainName};
       info->noAliasDomain = llvm::MDNode::get(ctx, Args);
       // Remove the dummy and replace it with a self-reference.
@@ -6509,7 +6519,7 @@ DEFINE_PRIM(DEBUG_TRAP) {
   }
   else {
     #ifdef HAVE_LLVM
-    ret.val = info->irBuilder->CreateIntrinsic(llvm::Intrinsic::debugtrap, {}, {});
+    ret.val = CreateIntrinsic(llvm::Intrinsic::debugtrap, {}, {});
     trackLLVMValue(ret.val);
     #endif
   }

--- a/compiler/codegen/cg-expr.cpp
+++ b/compiler/codegen/cg-expr.cpp
@@ -2204,11 +2204,7 @@ GenRet codegenMod(GenRet a, GenRet b)
 static llvm::CallInst* CreateIntrinsic(llvm::Intrinsic::ID id,
                                         llvm::ArrayRef<llvm::Type*> tys,
                                         llvm::ArrayRef<llvm::Value*> args) {
-#if LLVM_VERSION_MAJOR >= 21
-  auto call = gGenInfo->irBuilder->CreateIntrinsic(id, tys, args, {});
-#else
   auto call = gGenInfo->irBuilder->CreateIntrinsic(id, tys, args);
-#endif
   trackLLVMValue(call);
   return call;
 }

--- a/compiler/codegen/cg-type.cpp
+++ b/compiler/codegen/cg-type.cpp
@@ -126,7 +126,7 @@ static void codegenFunctionTypeLocal(FunctionType* ft) {
     // The final type is a pointer to the underlying function type.
     auto& layout = gGenInfo->module->getDataLayout();
     auto addrSpace = layout.getAllocaAddrSpace();
-    llvm::Type* t = llvm::PointerType::get(baseType, addrSpace);
+    llvm::Type* t = getPointerType(baseType, addrSpace);
 
     if (!ft->symbol->hasLLVMType()) {
       gGenInfo->lvt->addGlobalType(ft->symbol->cname, t, false);
@@ -541,7 +541,7 @@ void AggregateType::codegenDef() {
     } else {
 #ifdef HAVE_LLVM
       llvm::Type* llBaseType = baseForLLVMPointer(base)->getLLVMType();
-      type = llvm::PointerType::getUnqual(llBaseType);
+      type = getPointerType(llBaseType);
       structAlignment = ALIGNMENT_DEFER; // or pointer alignment
 #endif
     }
@@ -556,7 +556,7 @@ void AggregateType::codegenDef() {
     } else {
 #ifdef HAVE_LLVM
       llvm::Type* llBaseType = baseForLLVMPointer(base)->getLLVMType();
-      type = llvm::PointerType::getUnqual(llBaseType);
+      type = getPointerType(llBaseType);
       structAlignment = ALIGNMENT_DEFER; // or pointer alignment
 #endif
     }
@@ -628,7 +628,7 @@ void AggregateType::codegenDef() {
 
         if (isOpaquePointer(llBaseType)) {
           // No need to compute the element type for an opaque pointer
-          globalPtrTy = llvm::PointerType::get(gContext->llvmContext(),
+          globalPtrTy = getPointerType(gContext->llvmContext(),
                                                globalAddressSpace);
         } else {
 #ifdef HAVE_LLVM_TYPED_POINTERS
@@ -636,7 +636,7 @@ void AggregateType::codegenDef() {
           // of a wide pointer is always a local address.
           llvm::Type* eltType = llBaseType->getPointerElementType();
           INT_ASSERT(eltType);
-          globalPtrTy = llvm::PointerType::get(eltType, globalAddressSpace);
+          globalPtrTy = lgetPointerType(eltType, globalAddressSpace);
 #endif
         }
 
@@ -719,7 +719,7 @@ void AggregateType::codegenPrototype() {
       st = llvm::StructType::create(info->module->getContext(), struct_name);
       info->lvt->addGlobalType(struct_name, st, false);
 
-      llvm::PointerType* pt = llvm::PointerType::getUnqual(st);
+      auto pt = getPointerType(st);
       info->lvt->addGlobalType(symbol->cname, pt, false);
       symbol->llvmImplType = st;
 #endif

--- a/compiler/codegen/cg-type.cpp
+++ b/compiler/codegen/cg-type.cpp
@@ -636,7 +636,7 @@ void AggregateType::codegenDef() {
           // of a wide pointer is always a local address.
           llvm::Type* eltType = llBaseType->getPointerElementType();
           INT_ASSERT(eltType);
-          globalPtrTy = lgetPointerType(eltType, globalAddressSpace);
+          globalPtrTy = getPointerType(eltType, globalAddressSpace);
 #endif
         }
 

--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -299,7 +299,7 @@ static void genGlobalRawString(const char *cname, std::string &value, size_t len
 static void
 genGlobalVoidPtr(const char* cname, bool isHeader, bool isConstant=true) {
   GenInfo* info = gGenInfo;
-  llvm::Type* voidPtrTy = getPointerType(info->module->getContext(), 1);
+  auto voidPtrTy = getPointerType(info->module->getContext(), 1);
   llvm::GlobalVariable *global = llvm::cast<llvm::GlobalVariable>(
       info->module->getOrInsertGlobal(cname, voidPtrTy));
   global->setInitializer(llvm::Constant::getNullValue(voidPtrTy));
@@ -1499,7 +1499,7 @@ static void genGlobalSerializeTable(GenInfo* info) {
     fprintf(hdrfile, "\n};\n");
   } else if (!gCodegenGPU) {
 #ifdef HAVE_LLVM
-    llvm::Type *global_serializeTableEntryType =
+    auto global_serializeTableEntryType =
       getPointerType(info->module->getContext());
 
     std::vector<llvm::Constant *> global_serializeTable;
@@ -2122,7 +2122,7 @@ static void codegen_header(std::set<const char*> & cnames,
     fprintf(hdrfile, "\nextern void* const chpl_private_broadcast_table[];\n");
   } else if(!gCodegenGPU) {
 #ifdef HAVE_LLVM
-    llvm::Type *private_broadcastTableEntryType =
+    auto private_broadcastTableEntryType =
       getPointerType(info->module->getContext());
 
     std::vector<llvm::Constant *> private_broadcastTable;

--- a/compiler/include/llvmUtil.h
+++ b/compiler/include/llvmUtil.h
@@ -127,6 +127,8 @@ llvm::Type* tryComputingPointerElementType(llvm::Value* ptr);
 // Newer LLVMs don't distinguish between pointer type, these return an opaque `ptr`
 llvm::Type* getPointerType(llvm::LLVMContext& ctx, unsigned AS=0);
 llvm::Type* getPointerType(llvm::IRBuilder<>* irBuilder, unsigned AS=0);
+// although this takes a type, it returns an opaque `ptr` on newer LLVMs
+llvm::Type* getPointerType(llvm::Type* eltType, unsigned AS=0);
 
 #endif //HAVE_LLVM
 #endif //LLVMUTIL_H

--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -2112,7 +2112,11 @@ static void setupModule()
   // Set the target triple.
   const llvm::Triple &Triple =
     clangInfo->Clang->getTarget().getTriple();
+#if LLVM_VERSION_MAJOR >= 21
   info->module->setTargetTriple(Triple);
+#else
+  info->module->setTargetTriple(Triple.getTriple());
+#endif
 
   // Always set the module layout. This works around an apparent bug in
   // clang or LLVM (trivial/deitz/test_array_low.chpl would print out the
@@ -2180,6 +2184,7 @@ static void setupModule()
 #endif
 
   // Create the target machine.
+#if LLVM_VERSION_MAJOR >= 21
   info->targetMachine = Target->createTargetMachine(Triple,
                                                     cpu,
                                                     featuresString,
@@ -2187,6 +2192,15 @@ static void setupModule()
                                                     relocModel,
                                                     codeModel,
                                                     optLevel);
+#else
+  info->targetMachine = Target->createTargetMachine(Triple.getTriple(),
+                                                    cpu,
+                                                    featuresString,
+                                                    Options,
+                                                    relocModel,
+                                                    codeModel,
+                                                    optLevel);
+#endif
 
 
 
@@ -4530,7 +4544,11 @@ static void linkBitCodeFile(const char *bitCodeFilePath) {
 
   // adjust it
   const llvm::Triple &Triple = info->clangInfo->Clang->getTarget().getTriple();
+#if LLVM_VERSION_MAJOR >= 21
   bcLib->setTargetTriple(Triple);
+#else
+  bcLib->setTargetTriple(Triple.getTriple());
+#endif
   bcLib->setDataLayout(info->clangInfo->asmTargetLayoutStr);
 
   // link

--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -4653,8 +4653,8 @@ void setupForGlobalToWide(void) {
   const char* dummy = "chpl_wide_opt_dummy";
   if( getFunctionLLVM(dummy) ) INT_FATAL("dummy function already exists");
 
-  llvm::Type* retType = getPointerType(ginfo->module->getContext());
-  llvm::Type* argType = llvm::Type::getInt64Ty(ginfo->module->getContext());
+  auto retType = getPointerType(ginfo->module->getContext());
+  auto argType = llvm::Type::getInt64Ty(ginfo->module->getContext());
   llvm::Value* fval = ginfo->module->getOrInsertFunction(
                         dummy, retType, argType).getCallee();
   llvm::Function* fn = llvm::dyn_cast<llvm::Function>(fval);
@@ -4748,7 +4748,7 @@ void checkAdjustedDataLayout() {
 
   // Check that the data layout setting worked
   const llvm::DataLayout& dl = info->module->getDataLayout();
-  llvm::Type* testTy = getPointerType(info->module->getContext(), GLOBAL_PTR_SPACE);
+  auto testTy = getPointerType(info->module->getContext(), GLOBAL_PTR_SPACE);
   INT_ASSERT(dl.getTypeSizeInBits(testTy) == GLOBAL_PTR_SIZE);
 }
 

--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -1685,11 +1685,20 @@ void setupClang(GenInfo* info, std::string mainFile)
   CompilerInstance* Clang = new CompilerInstance();
   auto diagOptions = clang::CreateAndPopulateDiagOpts(clangInfo->driverArgsCStrings);
   auto diagClient = new clang::TextDiagnosticPrinter(llvm::errs(),
-                                                     &*diagOptions);
+#if LLVM_VERSION_MAJOR >= 21
+                                                     *diagOptions
+#else
+                                                      diagOptions.get()
+#endif
+                                                    );
 #if LLVM_VERSION_MAJOR >= 20
   auto clangDiags =
     clang::CompilerInstance::createDiagnostics(*llvm::vfs::getRealFileSystem(),
+#if LLVM_VERSION_MAJOR >= 21
+                                              *diagOptions,
+#else
                                                diagOptions.release(),
+#endif
                                                diagClient,
                                                /* owned */ true);
 #else
@@ -2103,7 +2112,7 @@ static void setupModule()
   // Set the target triple.
   const llvm::Triple &Triple =
     clangInfo->Clang->getTarget().getTriple();
-  info->module->setTargetTriple(Triple.getTriple());
+  info->module->setTargetTriple(Triple);
 
   // Always set the module layout. This works around an apparent bug in
   // clang or LLVM (trivial/deitz/test_array_low.chpl would print out the
@@ -2171,7 +2180,7 @@ static void setupModule()
 #endif
 
   // Create the target machine.
-  info->targetMachine = Target->createTargetMachine(Triple.str(),
+  info->targetMachine = Target->createTargetMachine(Triple,
                                                     cpu,
                                                     featuresString,
                                                     Options,
@@ -4521,7 +4530,7 @@ static void linkBitCodeFile(const char *bitCodeFilePath) {
 
   // adjust it
   const llvm::Triple &Triple = info->clangInfo->Clang->getTarget().getTriple();
-  bcLib->setTargetTriple(Triple.getTriple());
+  bcLib->setTargetTriple(Triple);
   bcLib->setDataLayout(info->clangInfo->asmTargetLayoutStr);
 
   // link
@@ -4556,15 +4565,15 @@ static void linkGpuDeviceLibraries() {
   GenInfo* info = gGenInfo;
 
   // save external functions
-  std::set<std::string> externals;
-  for (auto it = info->module->begin() ; it!= info->module->end() ; ++it) {
-    if (it->hasExternalLinkage()) {
-      externals.insert(it->getGlobalIdentifier());
+  std::unordered_set<llvm::GlobalValue::GUID> externals;
+  for (const auto& f: info->module->functions()) {
+    if (f.hasExternalLinkage()) {
+      externals.insert(f.getGUID());
     }
   }
-  for (auto it = info->module->global_begin() ; it!= info->module->global_end() ; ++it) {
-    if (it->hasExternalLinkage()) {
-      externals.insert(it->getGlobalIdentifier());
+  for (const auto& g: info->module->globals()) {
+    if (g.hasExternalLinkage()) {
+      externals.insert(g.getGUID());
     }
   }
 
@@ -4602,7 +4611,7 @@ static void linkGpuDeviceLibraries() {
 
   // internalize all functions that are not in `externals`
   llvm::InternalizePass iPass([&externals](const llvm::GlobalValue& gv) {
-    return externals.count(gv.getGlobalIdentifier()) > 0;
+    return externals.count(gv.getGUID()) > 0;
   });
   iPass.internalizeModule(*info->module);
 }

--- a/compiler/llvm/llvmAggregateGlobalOps.cpp
+++ b/compiler/llvm/llvmAggregateGlobalOps.cpp
@@ -431,9 +431,9 @@ Instruction *AggregateGlobalOpsOpt::tryAggregating(Instruction *StartInst, Value
   Module* M = StartInst->getParent()->getParent()->getParent();
   LLVMContext& Context = StartInst->getContext();
 
-  Type* int8Ty = Type::getInt8Ty(Context);
-  Type* sizeTy = DL->getIntPtrType(Context, 0);
-  Type* globalInt8PtrTy = llvm::PointerType::get(int8Ty, globalSpace);
+  auto int8Ty = Type::getInt8Ty(Context);
+  auto sizeTy = DL->getIntPtrType(Context, 0);
+  auto globalInt8PtrTy = getPointerType(int8Ty, globalSpace);
   bool isLoad = isa<LoadInst>(StartInst);
   bool isStore = isa<StoreInst>(StartInst);
   Instruction *lastAddedInsn = NULL;
@@ -647,9 +647,9 @@ Instruction *AggregateGlobalOpsOpt::tryAggregating(Instruction *StartInst, Value
                                                    offsets);
         trackLLVMValue(i8Dst);
 
-        Type* StoreType = oldStore->getValueOperand()->getType();
-        Type* PtrType = llvm::PointerType::getUnqual(StoreType);
-        Value* Dst = irBuilder.CreatePointerCast(i8Dst, PtrType);
+        auto StoreType = oldStore->getValueOperand()->getType();
+        auto PtrType = getPointerType(StoreType);
+        auto* Dst = irBuilder.CreatePointerCast(i8Dst, PtrType);
         trackLLVMValue(Dst);
 
         StoreInst* newStore =
@@ -674,8 +674,8 @@ Instruction *AggregateGlobalOpsOpt::tryAggregating(Instruction *StartInst, Value
     if( isLoad ) addrSpaceSrc = globalSpace;
 
     Type *types[3];
-    types[0] = llvm::PointerType::get(int8Ty, addrSpaceDst);
-    types[1] = llvm::PointerType::get(int8Ty, addrSpaceSrc);
+    types[0] = getPointerType(int8Ty, addrSpaceDst);
+    types[1] = getPointerType(int8Ty, addrSpaceSrc);
     types[2] = sizeTy;
 
 #if LLVM_VERSION_MAJOR >= 20
@@ -733,8 +733,8 @@ Instruction *AggregateGlobalOpsOpt::tryAggregating(Instruction *StartInst, Value
                                                    offsets);
         trackLLVMValue(i8Src);
 
-        Type* LoadType = oldLoad->getType();
-        Type* PtrType = llvm::PointerType::getUnqual(LoadType);
+        auto LoadType = oldLoad->getType();
+        auto PtrType = getPointerType(LoadType);
 
         Value* Src = irBuilder.CreatePointerCast(i8Src, PtrType);
         trackLLVMValue(Src);

--- a/compiler/llvm/llvmGlobalToWide.cpp
+++ b/compiler/llvm/llvmGlobalToWide.cpp
@@ -1304,7 +1304,7 @@ bool GlobalToWide::run(Module &M) {
       if( debugThisFn[0] || debugAllPassOne || debugAllPassTwo ) {
         dbgs() << "GlobalToWide: ";
         dbgs().write_escaped(M.getModuleIdentifier()) << '\n';
-        dbgs().write_escaped(M.getTargetTriple()) << '\n';
+        dbgs().write_escaped(M.getTargetTriple().str()) << '\n';
       }
 
       // Normally we expect a user of this optimization to have

--- a/compiler/llvm/llvmGlobalToWide.cpp
+++ b/compiler/llvm/llvmGlobalToWide.cpp
@@ -1304,7 +1304,11 @@ bool GlobalToWide::run(Module &M) {
       if( debugThisFn[0] || debugAllPassOne || debugAllPassTwo ) {
         dbgs() << "GlobalToWide: ";
         dbgs().write_escaped(M.getModuleIdentifier()) << '\n';
+#if LLVM_VERSION_MAJOR >= 21
         dbgs().write_escaped(M.getTargetTriple().str()) << '\n';
+#else
+        dbgs().write_escaped(M.getTargetTriple()) << '\n';
+#endif
       }
 
       // Normally we expect a user of this optimization to have

--- a/compiler/llvm/llvmUtil.cpp
+++ b/compiler/llvm/llvmUtil.cpp
@@ -508,8 +508,8 @@ llvm::Value *convertValueToType(llvm::IRBuilder<>* irBuilder,
       // todo: setValueAlignment(tmp_alloc, ???, ???);
       *alloca = tmp_alloc;
       // Now cast the allocation to both fromType and toType.
-      llvm::Type* curPtrType = llvm::PointerType::getUnqual(curType);
-      llvm::Type* newPtrType = llvm::PointerType::getUnqual(newType);
+      auto curPtrType = getPointerType(curType);
+      auto newPtrType = getPointerType(newType);
       // Now get cast pointers
       llvm::Value* tmp_cur = irBuilder->CreatePointerCast(tmp_alloc, curPtrType);
       trackLLVMValue(tmp_cur);
@@ -849,6 +849,13 @@ llvm::Type* getPointerType(llvm::IRBuilder<>* irBuilder, unsigned AS) {
   return irBuilder->getPtrTy(AS);
 #else
   return irBuilder->getInt8PtrTy(AS);
+#endif
+}
+llvm::Type* getPointerType(llvm::Type* eltType, unsigned AS) {
+#if LLVM_VERSION_MAJOR < 21
+  return llvm::PointerType::get(eltType, AS);
+#else
+  return llvm::PointerType::get(eltType->getContext(), AS);
 #endif
 }
 

--- a/doc/rst/usingchapel/prereqs.rst
+++ b/doc/rst/usingchapel/prereqs.rst
@@ -37,7 +37,7 @@ for using Chapel:
   * CMake is available and ``cmake`` runs version 3.20 or later.
 
   * The LLVM backend is now the default and it is easiest to use it with a
-    system-wide installation of LLVM and clang. LLVM versions 14 through 20 are
+    system-wide installation of LLVM and clang. LLVM versions 14 through 21 are
     currently supported. If a system-wide installation of LLVM and clang with
     one of those versions is not available, you can use the bundled LLVM or
     disable LLVM support (see :ref:`readme-chplenv.CHPL_LLVM`).

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1769170682,
+        "narHash": "sha256-oMmN1lVQU0F0W2k6OI3bgdzp2YOHWYUAw79qzDSjenU=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "c5296fdd05cfa2c187990dd909864da9658df755",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -50,6 +50,7 @@
           python312Packages.virtualenv
           python312Packages.setuptools
           makeWrapper
+          autoPatchelfHook
         ];
 
         # LLVM-specific inputs

--- a/flake.nix
+++ b/flake.nix
@@ -49,6 +49,7 @@
           python312Packages.pip
           python312Packages.virtualenv
           python312Packages.setuptools
+          makeWrapper
         ];
 
         # LLVM-specific inputs
@@ -185,6 +186,16 @@
               # Remove broken symlinks that point to /build directory
               # These are test files from hwloc and are not needed at runtime
               find $out -xtype l -delete 2>/dev/null || true
+            '';
+
+            # Wrap binaries to set CHPL_HOME environment variable
+            postFixup = ''
+              for prog in $out/bin/*; do
+                if [ -f "$prog" ] && [ -x "$prog" ]; then
+                  wrapProgram "$prog" \
+                    --set CHPL_HOME "$out/share/chapel"
+                fi
+              done
             '';
 
             # Also disable the broken symlinks check as a fallback

--- a/flake.nix
+++ b/flake.nix
@@ -177,15 +177,13 @@
               # Copy Makefiles needed for compilation
               cp Makefile* $out/share/chapel/ 2>/dev/null || true
 
-              # Remove broken symlinks that point to /build directory
-              # These are test files from hwloc that aren't needed at runtime
-              find $out -type l ! -exec test -e {} \; -delete 2>/dev/null || true
-
               runHook postInstall
             '';
 
-            # Don't check for broken symlinks (we clean them up in installPhase)
-            dontFixup = false;
+            # Remove broken symlinks before fixup phase runs its checks
+            preFixup = ''
+              find $out -type l ! -exec test -e {} \; -delete 2>/dev/null || true
+            '';
 
             meta = with pkgs.lib; {
               description = "A productive parallel programming language";

--- a/flake.nix
+++ b/flake.nix
@@ -121,6 +121,14 @@
               then "-I${llvmPackages.libclang.dev}/include -I${pkgs.glibc.dev}/include"
               else "";
 
+            # Fix shebangs that use /usr/bin/env (doesn't exist in Nix sandbox)
+            postPatch = ''
+              patchShebangs util/
+              patchShebangs compiler/
+              patchShebangs tools/
+              patchShebangs make/
+            '';
+
             configurePhase = ''
               runHook preConfigure
 

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,373 @@
+{
+  description = "Chapel - A Productive Parallel Programming Language";
+
+  nixConfig = {
+    extra-experimental-features = "nix-command flakes";
+  };
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+
+        # Chapel version
+        version = "2.7.0";
+
+        # LLVM version configuration
+        # Chapel 2.7 supports LLVM 14-21 (21 is the newest supported version)
+        #
+        # Default: Use bundled LLVM for LLVM 21 support (Chapel bundles LLVM 19.1.3,
+        # but this branch adds LLVM 21 support which can be used with system LLVM 21)
+        #
+        # For system LLVM builds, available nixpkgs options:
+        #   llvmPackages_14 through llvmPackages_19
+        # LLVM 20/21 packages will be added to nixpkgs when released
+        llvmPackages = pkgs.llvmPackages_19;
+
+        # Default to bundled LLVM for maximum compatibility and LLVM 21 testing
+        defaultChplLlvm = "bundled";
+
+        # Common build inputs for Chapel
+        commonBuildInputs = with pkgs; [
+          cmake
+          gnumake
+          gcc
+          gmp
+          libedit
+          perl
+          m4
+          pkg-config
+          git
+          file
+          which
+          python312
+          python312Packages.pip
+          python312Packages.virtualenv
+          python312Packages.setuptools
+        ];
+
+        # LLVM-specific inputs
+        llvmInputs = [
+          llvmPackages.llvm
+          llvmPackages.llvm.dev
+          llvmPackages.clang
+          llvmPackages.libclang
+          llvmPackages.libclang.dev
+        ];
+
+        # Source filtering to exclude build artifacts and .git
+        src = pkgs.lib.cleanSourceWith {
+          src = ./.;
+          filter = path: type:
+            let
+              baseName = baseNameOf path;
+              relPath = pkgs.lib.removePrefix (toString ./. + "/") path;
+            in
+            # Exclude build artifacts and large directories
+            !(baseName == ".git" ||
+              baseName == "build" ||
+              baseName == "third-party/llvm/llvm-src" ||
+              pkgs.lib.hasSuffix ".o" baseName ||
+              pkgs.lib.hasSuffix ".a" baseName ||
+              baseName == "__pycache__" ||
+              baseName == ".nix-profile" ||
+              baseName == "result");
+        };
+
+        # Base Chapel derivation builder
+        mkChapel = { chplLlvm ? "system", chplComm ? "none", extraBuildInputs ? [] }:
+          pkgs.stdenv.mkDerivation rec {
+            pname = "chapel";
+            inherit version src;
+
+            nativeBuildInputs = commonBuildInputs ++
+              (if chplLlvm == "system" then llvmInputs else []) ++
+              extraBuildInputs;
+
+            buildInputs = with pkgs; [
+              gmp
+              libedit
+              protobuf
+            ];
+
+            # Critical Chapel environment variables
+            CHPL_HOME = ".";
+            CHPL_LLVM = chplLlvm;
+            CHPL_COMM = chplComm;
+            CHPL_GMP = "system";
+            CHPL_TARGET_CPU = "none";  # Important for portability
+
+            # LLVM-specific environment (only when using system LLVM)
+            CHPL_LLVM_CONFIG = if chplLlvm == "system"
+              then "${llvmPackages.llvm.dev}/bin/llvm-config"
+              else "";
+            CHPL_HOST_COMPILER = if chplLlvm == "system" then "llvm" else "gnu";
+            CHPL_HOST_CC = if chplLlvm == "system"
+              then "${llvmPackages.clang}/bin/clang"
+              else "${pkgs.gcc}/bin/gcc";
+            CHPL_HOST_CXX = if chplLlvm == "system"
+              then "${llvmPackages.clang}/bin/clang++"
+              else "${pkgs.gcc}/bin/g++";
+            CHPL_TARGET_CC = CHPL_HOST_CC;
+            CHPL_TARGET_CXX = CHPL_HOST_CXX;
+
+            # Clang include paths for system LLVM
+            CHPL_CLANG_INCLUDES = if chplLlvm == "system"
+              then "-I${llvmPackages.libclang.dev}/include -I${pkgs.glibc.dev}/include"
+              else "";
+
+            configurePhase = ''
+              runHook preConfigure
+
+              export CHPL_HOME=$PWD
+
+              # Set up the Chapel environment
+              source util/setchplenv.bash
+
+              runHook postConfigure
+            '';
+
+            buildPhase = ''
+              runHook preBuild
+
+              # Build Chapel compiler
+              make -j$NIX_BUILD_CORES
+
+              # Build additional tools
+              make chpldoc mason
+
+              runHook postBuild
+            '';
+
+            installPhase = ''
+              runHook preInstall
+
+              # Use Chapel's install mechanism
+              mkdir -p $out
+
+              # Install binaries
+              mkdir -p $out/bin
+              cp -r bin/*/* $out/bin/ 2>/dev/null || true
+
+              # Install libraries
+              mkdir -p $out/lib
+              cp -r lib/* $out/lib/ 2>/dev/null || true
+
+              # Install CHPL_HOME structure for runtime compilation
+              mkdir -p $out/share/chapel
+              cp -r runtime $out/share/chapel/
+              cp -r modules $out/share/chapel/
+              cp -r make $out/share/chapel/
+              cp -r util $out/share/chapel/
+              cp -r compiler $out/share/chapel/ 2>/dev/null || true
+              cp -r third-party $out/share/chapel/ 2>/dev/null || true
+
+              # Copy Makefiles needed for compilation
+              cp Makefile* $out/share/chapel/ 2>/dev/null || true
+
+              runHook postInstall
+            '';
+
+            # Skip fixup for Chapel's complex directory structure
+            dontFixup = false;
+
+            meta = with pkgs.lib; {
+              description = "A productive parallel programming language";
+              longDescription = ''
+                Chapel is a programming language designed for productive parallel
+                computing at scale. It simplifies parallel programming through
+                high-level abstractions for data parallelism and task parallelism,
+                while still allowing low-level control when needed.
+              '';
+              homepage = "https://chapel-lang.org";
+              license = licenses.asl20;
+              platforms = platforms.unix;
+              maintainers = [ ];
+            };
+          };
+
+        # Language server derivation (uses local source)
+        mkChplLsp = pkgs.python312Packages.buildPythonApplication {
+          pname = "chpl-language-server";
+          inherit version;
+          pyproject = true;
+
+          # Use local source with filtering
+          src = ./tools/chpl-language-server;
+
+          build-system = with pkgs.python312Packages; [
+            setuptools
+          ];
+
+          propagatedBuildInputs = with pkgs.python312Packages; [
+            pygls
+            lsprotocol
+          ];
+
+          # Skip tests that require the full Chapel environment
+          doCheck = false;
+
+          meta = with pkgs.lib; {
+            description = "Chapel Language Server Protocol implementation";
+            homepage = "https://chapel-lang.org";
+            license = licenses.asl20;
+          };
+        };
+
+      in {
+        # ===================
+        # Packages
+        # ===================
+        packages = {
+          default = self.packages.${system}.chapel;
+
+          # Full Chapel with bundled LLVM (default for LLVM 21 support)
+          # Uses Chapel's included LLVM which supports versions 14-21
+          # Note: Requires ~4GB memory to build
+          chapel = mkChapel {
+            chplLlvm = "bundled";
+          };
+
+          # Chapel with system LLVM backend (LLVM 19 from nixpkgs)
+          # Faster to build if you have system LLVM available
+          chapel-system-llvm = mkChapel {
+            chplLlvm = "system";
+          };
+
+          # Chapel with GNU backend only (fastest build, no LLVM dependency)
+          chapel-gnu = mkChapel {
+            chplLlvm = "none";
+          };
+
+          # Chapel with GASNet for multi-locale
+          # NOTE: GASNet not in nixpkgs, would need custom derivation
+          # chapel-gasnet = mkChapel {
+          #   chplComm = "gasnet";
+          #   extraBuildInputs = [ gasnet ];  # Custom derivation needed
+          # };
+
+          # Language server (standalone)
+          chpl-language-server = mkChplLsp;
+        };
+
+        # ===================
+        # Development Shells
+        # ===================
+        devShells = {
+          # Default development shell with full Chapel
+          default = pkgs.mkShell {
+            buildInputs = commonBuildInputs ++ llvmInputs ++ [
+              pkgs.gmp
+              pkgs.libedit
+              pkgs.protobuf
+            ];
+
+            shellHook = ''
+              export CHPL_HOME=${self.packages.${system}.chapel}/share/chapel
+              export PATH=${self.packages.${system}.chapel}/bin:$PATH
+              echo "Chapel development environment loaded"
+              echo "Run 'chpl --version' to verify installation"
+            '';
+          };
+
+          # Minimal shell for running Chapel programs
+          minimal = pkgs.mkShell {
+            buildInputs = [
+              self.packages.${system}.chapel-gnu
+            ];
+
+            shellHook = ''
+              echo "Minimal Chapel environment (GNU backend only)"
+            '';
+          };
+
+          # Full development with all tools
+          full = pkgs.mkShell {
+            buildInputs = commonBuildInputs ++ llvmInputs ++ [
+              self.packages.${system}.chapel
+              self.packages.${system}.chpl-language-server
+              pkgs.fltk  # for chplvis
+              pkgs.doxygen
+              pkgs.sphinx
+            ];
+
+            shellHook = ''
+              export CHPL_HOME=${self.packages.${system}.chapel}/share/chapel
+              export PATH=${self.packages.${system}.chapel}/bin:$PATH
+              echo "Full Chapel development environment"
+              echo "Includes: chpl, chpldoc, mason, chpl-language-server"
+            '';
+          };
+
+          # Shell for Chapel development (building Chapel itself)
+          # This sets up all the LLVM environment variables correctly
+          chapel-dev = (pkgs.mkShell.override { stdenv = llvmPackages.stdenv; }) {
+            nativeBuildInputs = commonBuildInputs ++ llvmInputs ++ [
+              pkgs.gmp
+              pkgs.libedit
+              pkgs.protobuf
+              pkgs.doxygen
+              pkgs.sphinx
+            ];
+
+            shellHook = ''
+              # Critical LLVM environment variables for Chapel development
+              export CHPL_LLVM=system
+              export CHPL_LLVM_CONFIG=${llvmPackages.llvm.dev}/bin/llvm-config
+              export CHPL_HOST_COMPILER=llvm
+              export CHPL_HOST_CC=${llvmPackages.clang}/bin/clang
+              export CHPL_HOST_CXX=${llvmPackages.clang}/bin/clang++
+              export CHPL_TARGET_CC=${llvmPackages.clang}/bin/clang
+              export CHPL_TARGET_CXX=${llvmPackages.clang}/bin/clang++
+              export CHPL_CLANG_INCLUDES="-I${llvmPackages.libclang.dev}/include -I${pkgs.glibc.dev}/include"
+
+              # Reproducibility settings
+              export CHPL_GMP=system
+              export CHPL_TARGET_CPU=none
+
+              echo "Chapel compiler development environment"
+              echo "LLVM ${llvmPackages.llvm.version} configured"
+              echo ""
+              echo "Set CHPL_HOME to your Chapel source directory:"
+              echo "  export CHPL_HOME=\$PWD"
+              echo "  source util/setchplenv.bash"
+              echo "  make"
+            '';
+          };
+        };
+
+        # ===================
+        # Apps (nix run)
+        # ===================
+        apps = {
+          default = {
+            type = "app";
+            program = "${self.packages.${system}.chapel}/bin/chpl";
+          };
+
+          chpl = self.apps.${system}.default;
+
+          chpl-language-server = {
+            type = "app";
+            program = "${self.packages.${system}.chpl-language-server}/bin/chpl-language-server";
+          };
+        };
+
+      }
+    ) // {
+      # ===================
+      # Overlay (system-independent)
+      # ===================
+      overlays.default = final: prev: {
+        chapel = self.packages.${prev.system}.chapel;
+        chapel-system-llvm = self.packages.${prev.system}.chapel-system-llvm;
+        chapel-gnu = self.packages.${prev.system}.chapel-gnu;
+        chpl-language-server = self.packages.${prev.system}.chpl-language-server;
+      };
+    };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -177,10 +177,14 @@
               # Copy Makefiles needed for compilation
               cp Makefile* $out/share/chapel/ 2>/dev/null || true
 
+              # Remove broken symlinks that point to /build directory
+              # These are test files from hwloc that aren't needed at runtime
+              find $out -type l ! -exec test -e {} \; -delete 2>/dev/null || true
+
               runHook postInstall
             '';
 
-            # Skip fixup for Chapel's complex directory structure
+            # Don't check for broken symlinks (we clean them up in installPhase)
             dontFixup = false;
 
             meta = with pkgs.lib; {

--- a/flake.nix
+++ b/flake.nix
@@ -144,10 +144,9 @@
               runHook preBuild
 
               # Build Chapel compiler
+              # Note: chpldoc and mason require network access (pip install) which
+              # is blocked in the Nix sandbox, so we only build the core compiler
               make -j$NIX_BUILD_CORES
-
-              # Build additional tools
-              make chpldoc mason
 
               runHook postBuild
             '';

--- a/flake.nix
+++ b/flake.nix
@@ -182,8 +182,14 @@
 
             # Remove broken symlinks before fixup phase runs its checks
             preFixup = ''
-              find $out -type l ! -exec test -e {} \; -delete 2>/dev/null || true
+              # Remove broken symlinks that point to /build directory
+              # These are test files from hwloc and are not needed at runtime
+              find $out -xtype l -delete 2>/dev/null || true
             '';
+
+            # Also disable the broken symlinks check as a fallback
+            # (hwloc build directory contains symlinks that are only valid during build)
+            dontCheckForBrokenSymlinks = true;
 
             meta = with pkgs.lib; {
               description = "A productive parallel programming language";

--- a/frontend/lib/util/clang-integration.cpp
+++ b/frontend/lib/util/clang-integration.cpp
@@ -158,12 +158,12 @@ const std::vector<std::string>& getCC1Arguments(Context* context,
 
   std::string triple = llvm::sys::getDefaultTargetTriple();
   // Create a compiler instance to handle the actual work.
-  auto diagOptions = std::make_unique<clang::DiagnosticOptions>();
+  auto diagOptions = new clang::DiagnosticOptions();
   auto diagClient = new clang::TextDiagnosticPrinter(llvm::errs(),
 #if LLVM_VERSION_MAJOR >= 21
-                                                    *diagOptions
+                                                     *diagOptions
 #else
-                                                     diagOptions.get()
+                                                     &*diagOptions
 #endif
                                                     );
   auto diagID = new clang::DiagnosticIDs();
@@ -172,7 +172,7 @@ const std::vector<std::string>& getCC1Arguments(Context* context,
 #if LLVM_VERSION_MAJOR >= 21
     *diagOptions,
 #else
-    diagOptions.get(),
+    &*diagOptions,
 #endif
     diagClient);
 
@@ -219,6 +219,8 @@ const std::vector<std::string>& getCC1Arguments(Context* context,
       result.push_back(arg);
     }
   }
+
+  delete diags;
 
 #endif
 
@@ -307,14 +309,14 @@ createClangPrecompiledHeader(Context* context, ID externBlockId) {
     auto diagOptions = clang::CreateAndPopulateDiagOpts(cc1argsCstrs);
     auto diagClient = new clang::TextDiagnosticBuffer();
 #if LLVM_VERSION_MAJOR >= 21
-      auto clangDiags =
+    auto clangDiags =
       clang::CompilerInstance::createDiagnostics(*llvm::vfs::getRealFileSystem(),
                                                  *diagOptions,
                                                  diagClient,
                                                  /* owned */ true);
 #else
 #if LLVM_VERSION_MAJOR >= 20
-      auto clangDiags =
+    auto clangDiags =
       clang::CompilerInstance::createDiagnostics(*llvm::vfs::getRealFileSystem(),
                                                  diagOptions.release(),
                                                  diagClient,

--- a/test/llvm/abi/aarch64-darwin/export-vs-c-llvm21.good
+++ b/test/llvm/abi/aarch64-darwin/export-vs-c-llvm21.good
@@ -1,0 +1,1 @@
+export-vs-c-llvm18.good

--- a/test/llvm/abi/x86-64/export-vs-c-llvm21.good
+++ b/test/llvm/abi/x86-64/export-vs-c-llvm21.good
@@ -1,0 +1,1 @@
+export-vs-c-llvm18.good

--- a/util/chplenv/chpl_llvm.py
+++ b/util/chplenv/chpl_llvm.py
@@ -17,6 +17,7 @@ def llvm_versions():
     # Which major release - only need one number for that with current
     # llvm (since LLVM 4.0).
     # These will be tried in order.
+    # return ('21','20','19','18','17','16','15','14',)
     return ('20','19','18','17','16','15','14',)
 
 @memoize

--- a/util/chplenv/chpl_llvm.py
+++ b/util/chplenv/chpl_llvm.py
@@ -17,8 +17,7 @@ def llvm_versions():
     # Which major release - only need one number for that with current
     # llvm (since LLVM 4.0).
     # These will be tried in order.
-    # return ('21','20','19','18','17','16','15','14',)
-    return ('20','19','18','17','16','15','14',)
+    return ('21','20','19','18','17','16','15','14',)
 
 @memoize
 def get_uniq_cfg_path_for(llvm_val, llvm_support_val):


### PR DESCRIPTION
Adding some things I want here on this `jesssullivan/chapel` fork, mostly relating to learning / experimenting with nix flakes and off-github work with LLVM 21.  

- [x] include [27941](https://github.com/chapel-lang/chapel/pull/27941) & [28002](https://github.com/chapel-lang/chapel/pull/28002)
- [x] Split out container for multistage builds and be all OCI cache friendly 
- [ ] figure out github actions as a confused, curmudgeonly gitlab runner native :world_map: 
 

Add flake.nix with LLVM 21 support (bundled LLVM default)
  - chapel: bundled LLVM for LLVM 14-21 support
  - chapel-system-llvm: system LLVM 19 from nixpkgs
  - chapel-gnu: GNU backend only (no LLVM)
  - chpl-language-server: standalone LSP package
  - Development shells with proper LLVM environment

- Add Containerfile.multi-stage with LLVM 21 default
  - 6-stage build for modular deployment
  - Auto-adds LLVM.org apt repo for versions >= 20
  - Targets: chapel-full, chapel-lsp, chapel-runtime, chapel-gasnet

- Add .github/workflows/nix.yml for Nix CI
  - Flake check, GNU build, system LLVM build, dev shell test

- Update prereqs.rst to document LLVM 21 support