### PR TITLE
feat(ci): use self-hosted ARC runners for Nix builds

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -48,83 +48,57 @@ jobs:
 
   build-chapel-gnu:
     name: Build Chapel (GNU backend)
-    runs-on: ubuntu-latest
+    runs-on: chapel-nix
     needs: flake-check
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Nix
-        uses: cachix/install-nix-action@v27
+      - uses: tinyland-inc/GloriousFlywheel/.github/actions/nix-job@main
         with:
-          nix_path: nixpkgs=channel:nixos-unstable
-          extra_nix_config: |
-            experimental-features = nix-command flakes
-
-      - name: Build chapel-gnu
-        run: |
-          nix build .#chapel-gnu --print-build-logs
-          ./result/bin/chpl --version
+          command: |
+            nix build .#chapel-gnu --print-build-logs
+            ./result/bin/chpl --version
 
   build-chapel-bundled-llvm:
     name: Build Chapel (Bundled LLVM - supports LLVM 21)
-    runs-on: ubuntu-latest
+    runs-on: chapel-nix
     needs: flake-check
     # This is a long build (~4GB memory), only run on main or when explicitly requested
     if: github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Nix
-        uses: cachix/install-nix-action@v27
+      - uses: tinyland-inc/GloriousFlywheel/.github/actions/nix-job@main
         with:
-          nix_path: nixpkgs=channel:nixos-unstable
-          extra_nix_config: |
-            experimental-features = nix-command flakes
-
-      - name: Build chapel (bundled LLVM)
-        run: |
-          nix build .#chapel --print-build-logs
-          ./result/bin/chpl --version
+          command: |
+            nix build .#chapel --print-build-logs
+            ./result/bin/chpl --version
 
   build-chapel-system-llvm:
     name: Build Chapel (System LLVM 19)
-    runs-on: ubuntu-latest
+    runs-on: chapel-nix
     needs: flake-check
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Nix
-        uses: cachix/install-nix-action@v27
+      - uses: tinyland-inc/GloriousFlywheel/.github/actions/nix-job@main
         with:
-          nix_path: nixpkgs=channel:nixos-unstable
-          extra_nix_config: |
-            experimental-features = nix-command flakes
-
-      - name: Build chapel-system-llvm
-        run: |
-          nix build .#chapel-system-llvm --print-build-logs
-          ./result/bin/chpl --version
+          command: |
+            nix build .#chapel-system-llvm --print-build-logs
+            ./result/bin/chpl --version
 
   dev-shell:
     name: Test Dev Shell
-    runs-on: ubuntu-latest
+    runs-on: chapel-nix
     needs: flake-check
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Nix
-        uses: cachix/install-nix-action@v27
+      - uses: tinyland-inc/GloriousFlywheel/.github/actions/nix-job@main
         with:
-          nix_path: nixpkgs=channel:nixos-unstable
-          extra_nix_config: |
-            experimental-features = nix-command flakes
-
-      - name: Test chapel-dev shell
-        run: |
-          nix develop .#chapel-dev --command bash -c '
+          command: |
             echo "Testing chapel-dev shell..."
             echo "CHPL_LLVM=$CHPL_LLVM"
             echo "CHPL_LLVM_CONFIG=$CHPL_LLVM_CONFIG"
             which clang
             llvm-config --version
-          '


### PR DESCRIPTION
## Summary

- Switch all Nix build jobs from `ubuntu-latest` to `chapel-nix` self-hosted ARC runners
- Use `tinyland-inc/GloriousFlywheel/.github/actions/nix-job` composite action for automatic Attic binary cache integration
- Keep `flake-check` on `ubuntu-latest` (lightweight, no build needed)

The bundled LLVM build currently takes ~2 hours on GitHub-hosted runners. On self-hosted runners with Attic cache, subsequent builds pull from cache in minutes.

## Changes

| Job | Before | After |
|-----|--------|-------|
| `flake-check` | `ubuntu-latest` | `ubuntu-latest` (unchanged) |
| `build-chapel-gnu` | `ubuntu-latest` + manual Nix install | `chapel-nix` + `nix-job` action |
| `build-chapel-bundled-llvm` | `ubuntu-latest` + manual Nix install | `chapel-nix` + `nix-job` action |
| `build-chapel-system-llvm` | `ubuntu-latest` + manual Nix install | `chapel-nix` + `nix-job` action |
| `dev-shell` | `ubuntu-latest` + manual Nix install | `chapel-nix` + `nix-job` action |

## Prerequisites

Requires GloriousFlywheel GitHub App installed on this account with the `chapel-nix` runner scale set deployed. Jobs will queue until infrastructure is ready.

## Test plan

- [ ] Trigger `workflow_dispatch` after runner infrastructure is deployed
- [ ] Verify builds complete and Attic cache is populated on first run
- [ ] Verify subsequent runs pull from cache